### PR TITLE
Avoid <nick /> element to be appended to outgoing muc presences

### DIFF
--- a/js/presence.js
+++ b/js/presence.js
@@ -750,7 +750,7 @@ function sendPresence(to, type, show, status, checksum, limit_history, password,
 	// Nickname
 	var nickname = getName();
 	
-	if(nickname)
+	if(nickname && !limit_history)
 		presence.appendNode('nick', {'xmlns': NS_NICK}, nickname);
 	
 	// vcard-temp:x:update node


### PR DESCRIPTION
It's really minimal change doesn't impact anything else.
And it prevents certain buggy clients (e.g. Miranda, Telepathy) to see people with the nickname specified into the element instead of their resource, it's also unsuggested by the spec.
