### PR TITLE
Allow connection callbacks functions on doLogin call

### DIFF
--- a/js/connection.js
+++ b/js/connection.js
@@ -17,7 +17,7 @@ var CURRENT_SESSION = false;
 function doLogin(lNick, lServer, lPass, lResource, lPriority, lRemember,loginOpts) {
 	try {
 		// get optionnal conn handlers
-		oextend = loginOpts || {};
+		oExtend = loginOpts || {};
 
 		// We remove the not completed class to avoid problems
 		$('#home .loginer input').removeClass('please-complete');


### PR DESCRIPTION
I made theses smalls changes to allow an array of callbacks to be given on the doLogin function. I use it on an overwrite of the connection.js functions and it's quite usefull to add some new behaviors after successfull login.
For example I can use it this way:
<code>
doLogin(username,domain,pass,resource,priority,false, {
      'onconnect' : function() {
        jQuery('.tools-all:first').remove();
        jQuery('.tools-all').css('float','left');
        jQuery("#buddy-list").hide();
        jQuery("#left-content").hide();
        jQuery("#right-content").css('left' , '0px');
        jQuery("div.update",jQuery("#channel")).hide();
      }
    });
</code>
