### PR TITLE
Jappix Mini: Allow nickname embedded in messages

### DIFF
--- a/js/jsjac.js
+++ b/js/jsjac.js
@@ -2211,6 +2211,32 @@ JSJaCMessage.prototype.setThread = function(thread) {
   return this;
 };
 /**
+ * Sets the 'nick' attribute for this message.
+ * This is sometime sused to detect the sender nickname when he's not in the roster
+ * @param {String} nickname
+ * @return this message
+ * @type JSJaCMessage
+ */
+JSJaCMessage.prototype.setNick = function(nick) {
+  var aNode = this.getChild("nick");
+  var tNode = this.getDoc().createTextNode(nick);
+  if (aNode)
+    try {
+      aNode.replaceChild(tNode,aNode.firstChild);
+    } catch (e) { }
+  else {
+    try {
+      aNode = this.getDoc().createElementNS('http://jabber.org/protocol/nick',
+                                            "nick");
+    } catch (ex) {
+      aNode = this.getDoc().createElement("nick")
+    }
+    this.getNode().appendChild(aNode);
+    aNode.appendChild(tNode);
+  }
+  return this;
+};
+/**
  * Gets the 'thread' identifier for this message
  * @return A thread identifier
  * @type String
@@ -2233,6 +2259,14 @@ JSJaCMessage.prototype.getBody = function() {
  */
 JSJaCMessage.prototype.getSubject = function() {
   return this.getChildVal('subject')
+};
+/**
+ * Gets the nickname of this message
+ * @return The nickname of this message
+ * @type String
+ */
+JSJaCMessage.prototype.getNick = function() {
+  return this.getChildVal('nick');
 };
 
 

--- a/js/mini.js
+++ b/js/mini.js
@@ -325,8 +325,29 @@ function handleMessageMini(msg) {
 				nick = jQuery('#jappix_mini a#friend-' + hash).text().revertHtmlEnc();
 				
 				// No nickname?
-				if(!nick)
-					nick = getXIDNick(xid);
+				if(!nick) {
+				    // if the roster does not give us any nick the user may have send us a nickname to use with his first message
+                                   // @see http://xmpp.org/extensions/xep-0172.html
+                                   // we first check we do not have made this stuff before
+                                   var unknown_entry = jQuery("a.jm_unknown[data-xid="+xid+"]",jQuery("#jappix_mini"));
+                                   if (unknown_entry.length > 0) {
+                                       nick =  unknown_entry.attr('data-nick');
+                                   } else {
+                                       msgnick = msg.getNick();
+                                       nick = getXIDNick(xid);
+                                       if (msgnick) {
+                                           if (nick != msgnick) {
+                                               // if there is a nickname in the message which differs from the jid-extracted nick then tell it to the user
+                                               nick = msgnick + ' (' + nick + ')';
+                                           }
+                                       }
+                                       //push that unknown guy in a temporary roster entry
+                                       var unknown_entry = jQuery('<a class="jm_unknown jm_offline" href="#"></a>')
+                                                           .attr('data-nick',nick)
+                                                           .attr('data-xid',xid);
+                                       unknown_entry.appendTo(jQuery(".jm_buddies",jQuery("#jappix_mini")));
+                                   }
+				}
 			}
 			
 			// Define the target div
@@ -663,7 +684,18 @@ function sendMessageMini(aForm) {
 		if(body && xid) {
 			// Send the message
 			var aMsg = new JSJaCMessage();
-			
+		
+			// if the roster does not give us any nick the user may have send us a nickname to use with his first message
+                        // @see http://xmpp.org/extensions/xep-0172.html
+			var known_roster_entry = jQuery("a.jm_friend[data-xid="+xid+"]",jQuery("#jappix_mini"));
+			if (0==known_roster_entry.length) {
+			        var subscription = known_roster_entry.attr('data-sub');
+			        // the other may not know my nickname if we do not have both a roster entry, or if he doesn't have one
+			        if ('both' != subscription && 'from' != subscription) {
+			                // Adding our nickname in the message, hard to know if this is just the first one
+			                aMsg.setNick(MINI_NICKNAME);
+			        }
+			}
 			aMsg.setTo(xid);
 			aMsg.setType(type);
 			aMsg.setBody(body);
@@ -1948,7 +1980,7 @@ function initializeMini() {
 }
 
 // Displays a roster buddy
-function addBuddyMini(xid, hash, nick, groupchat) {
+function addBuddyMini(xid, hash, nick, groupchat, subscription) {
 	// Element
 	var element = '#jappix_mini a.jm_friend#friend-' + hash;
 	
@@ -1974,8 +2006,18 @@ function addBuddyMini(xid, hash, nick, groupchat) {
 		}
 	}
 	
+	if (subscription) {
+	  substr = ' data-sub="' + subscription +'" ';
+	} else {
+	  substr = '';
+	}
 	// Append this buddy content
-	var code = '<a class="jm_friend jm_offline" id="friend-' + hash + '" data-xid="' + escape(xid) + '" data-nick="' + escape(nick) +  '" data-hash="' + hash + '" href="#"><span class="jm_presence jm_images jm_unavailable"></span>' + nick.htmlEnc() + '</a>';
+	var code = '<a class="jm_friend jm_offline" id="friend-' + hash
+	           + '" data-xid="' + escape(xid)
+	           + '" data-nick="' + escape(nick)
+	           +  '" data-hash="' + hash + '" href="#" '
+	           + substr + '><span class="jm_presence jm_images jm_unavailable"></span>'
+	           + nick.htmlEnc() + '</a>';
 	
 	if(groupchat)
 		jQuery(path).append(code);
@@ -2098,7 +2140,7 @@ function handleRosterMini(iq) {
     	if(subscription == 'remove')
 			removeBuddyMini(hash);
     	else
-			addBuddyMini(xid, hash, nick);
+			addBuddyMini(xid, hash, nick, null, subscription);
     }
     
 	// Not yet initialized


### PR DESCRIPTION
Reading Xep-0172 section 4.2 http://xmpp.org/extensions/xep-0172.html#message I found that for users which do not share rosters (subscritpion is not both) we could use a nick item in the message to transfer the nickname.
I've made some changes to allow that. Note that theses changes impact an addition on JSJaCMessage prototype.

In this branch I've also added a patch for bug #84, where the first contact of the roster is always removed. Somethin not related but it was on the roster managment code and some changes are made on mini roster managment on this branch to store the presence subscription status (both, from, to, etc) and also to store the 'unknown guy' presence.
