### PR TITLE
Ability to suspend statistics

### DIFF
--- a/index.php
+++ b/index.php
@@ -107,7 +107,9 @@ if(($include_app == 'desktop') || ($include_app == 'mobile')) {
 		$include_app = 'upload';
 	
 	// Save this visit (for the stats)
-	writeVisit();
+	if('off'!==STATISTICS) {
+		writeVisit();
+	}
 }
 
 // Include it!

--- a/lang/en/LC_MESSAGES/main.pot
+++ b/lang/en/LC_MESSAGES/main.pot
@@ -1905,3 +1905,6 @@ msgstr ""
 
 msgid "The key you provided does not have the permission to download this file"
 msgstr ""
+
+msgid "Statistics are currently disabled in the settings."
+msgstr ""

--- a/lang/fr/LC_MESSAGES/main.po
+++ b/lang/fr/LC_MESSAGES/main.po
@@ -1905,6 +1905,9 @@ msgstr "Quand vous vous connectez ou vous enregistrez, votre mot de passe doit r
 msgid "Jappix for your company."
 msgstr "Jappix pour votre entreprise."
 
+msgid "Statistics are currently disabled in the settings."
+msgstr "Les Statistiques sont actuellement suspendues dans la configuration."
+
 #~ msgid "Jappix is a non-profit social platform, that you can access wherever you are, whenever you want and communicate with whovever you want."
 #~ msgstr "Jappix est une plateforme sociale à but non lucratif, accessible n'importe où, n'importe quand pour communiquer avec qui vous voulez."
 

--- a/php/form-main.php
+++ b/php/form-main.php
@@ -80,6 +80,12 @@ if($compression == 'on')
 else
 	$check_compression = '';
 
+// Statistics
+if($statistics == 'on')
+	$check_statistics = $checked;
+else
+	$check_statistics = '';
+
 ?>
 
 <a class="info smallspace neutral" href="https://github.com/jappix/jappix/wiki/JappixApp" target="_blank"><?php _e("Need help? You'd better read our documentation page about how to fill this form!"); ?></a>
@@ -130,6 +136,8 @@ else
 	<label for="https_force"><?php _e("Force HTTPS"); ?></label><input id="https_force" type="checkbox" name="https_force"<?php echo $check_https_force; ?> />
 	
 	<label for="compression"><?php _e("Compression"); ?></label><input id="compression" type="checkbox" name="compression"<?php echo $check_compression; ?> />
+	
+	<label for="statistics"><?php _e("Statistics"); ?></label><input id="statistics" type="checkbox" name="statistics"<?php echo $check_statistics; ?> />
 	
 	<input type="hidden" name="multi_files" value="<?php echo $multi_files; ?>" />
 	

--- a/php/manager.php
+++ b/php/manager.php
@@ -270,7 +270,9 @@ else
 				<h3 class="statistics manager-images"><?php _e("Statistics"); ?></h3>
 				
 				<p><?php _e("Basic statistics are processed by Jappix about some important things, you can find them below."); ?></p>
-				
+				<?php if ('off'==STATISTICS) : ?>
+				  <p><?php _e("Statistics are currently disabled in the settings."); ?></p>
+				<?php else : ?>
 				<h4><?php _e("Access statistics"); ?></h4>
 				
 				<?php
@@ -331,6 +333,7 @@ else
 				</ul>
 				
 				<object class="stats" type="image/svg+xml" data="./php/stats-svg.php?l=<?php echo $locale; ?>&amp;g=others"></object>
+			<?php endif ?>
 			<?php }
 			
 			// Authorized and configuration page requested

--- a/php/post-main.php
+++ b/php/post-main.php
@@ -113,6 +113,12 @@ if(isset($_POST['compression']) && !empty($_POST['compression']))
 else
 	$compression = 'off';
 
+// Compression
+if(isset($_POST['statistics']) && !empty($_POST['statistics']))
+	$statistics = 'on';
+else
+	$statistics = 'off';
+	
 // Multiple resources
 if(isset($_POST['multi_files']) && ($_POST['multi_files'] == 'on'))
 	$multi_files = 'on';
@@ -144,7 +150,8 @@ $conf_xml =
 	<https_force>'.$https_force.'</https_force>
 	<compression>'.$compression.'</compression>
 	<multi_files>'.$multi_files.'</multi_files>
-	<developer>'.$developer.'</developer>'
+	<developer>'.$developer.'</developer>
+	<statistics>'.$statistics.'</statistics>'
 ;
 
 // Write the main configuration

--- a/php/read-main.php
+++ b/php/read-main.php
@@ -36,8 +36,9 @@ $main_conf = array(
 	     	'https_force'		=> 'off',
 	     	'compression'		=> 'off',
 	     	'multi_files'		=> 'off',
-	     	'developer'		=> 'off'
-	     );
+	     	'developer'		=> 'off',
+	     	'statistics'  => 'off'
+);
 
 // Define a default values array
 $main_default = $main_conf;
@@ -79,5 +80,6 @@ define('HTTPS_FORCE', $main_conf['https_force']);
 define('COMPRESSION', $main_conf['compression']);
 define('MULTI_FILES', $main_conf['multi_files']);
 define('DEVELOPER', $main_conf['developer']);
+define('STATISTICS', $main_conf['statistics']);
 
 ?>

--- a/php/vars-main.php
+++ b/php/vars-main.php
@@ -36,5 +36,6 @@ $https_force = htmlspecialchars(HTTPS_FORCE);
 $compression = htmlspecialchars(COMPRESSION);
 $multi_files = htmlspecialchars(MULTI_FILES);
 $developer = htmlspecialchars(DEVELOPER);
+$statistics = htmlspecialchars(STATISTICS);
 
 ?>


### PR DESCRIPTION
I'd like to be able to completly remove latency from the XML file read/write, especially because they are xml files and theses operations are by nature slow and not atomic (so wrong in term of statistics).
