### PR TITLE
Jappix Mini License

### DIFF
--- a/COPYING_MINI
+++ b/COPYING_MINI
@@ -1,0 +1,21 @@
+Code
+----
+
+The following notice applies to the files which state that they are dual-
+licensed under the MPL:
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Artwork
+-------
+
+The files img/sprites/mini.png and img/sprites/mini.gif were created by
+Vanaryon and are dual-licensed under the Creative Commons Attribution 2.5
+License and the Creative Commons Attribution 3.0 License.
+They contain work from the FamFamFam Silk icon set by Mark James.
+
+* http://famfamfam.com/lab/icons/silk/
+* http://creativecommons.org/licenses/by/2.5/
+* http://creativecommons.org/licenses/by/3.0/

--- a/css/mini-ie.css
+++ b/css/mini-ie.css
@@ -5,7 +5,7 @@ This is the Jappix Mini legacy IE CSS stylesheet
 
 -------------------------------------------------
 
-License: AGPL
+License: dual-licensed under AGPL and MPLv2
 Author: Vanaryon
 Last revision: 20/03/11
 

--- a/css/mini.css
+++ b/css/mini.css
@@ -5,8 +5,8 @@ This is the Jappix Mini CSS stylesheet
 
 -------------------------------------------------
 
-License: AGPL
-Authors: Vanaryon, Julien, hunterjm
+License: dual-licensed under AGPL and MPLv2
+Authors: Vanaryon, Julien, hunterjm, Kloadut
 Last revision: 09/04/12
 
 */

--- a/js/common.js
+++ b/js/common.js
@@ -5,8 +5,8 @@ These are the common JS script for Jappix
 
 -------------------------------------------------
 
-License: AGPL
-Authors: Vanaryon, olivierm
+License: dual-licensed under AGPL and MPLv2
+Authors: Vanaryon, olivierm, regilero
 Last revision: 09/04/12
 
 */

--- a/js/constants.js
+++ b/js/constants.js
@@ -5,8 +5,8 @@ These are the constants JS scripts for Jappix
 
 -------------------------------------------------
 
-License: AGPL
-Authors: Stefan Strigler, Vanaryon
+License: dual-licensed under AGPL and MPLv2
+Authors: Stefan Strigler, Vanaryon, Kloadut
 Last revision: 26/08/11
 
 */

--- a/js/datastore.js
+++ b/js/datastore.js
@@ -5,7 +5,7 @@ These are the temporary/persistent data store functions
 
 -------------------------------------------------
 
-License: AGPL
+License: dual-licensed under AGPL and MPLv2
 Author: Vanaryon
 Last revision: 23/06/11
 

--- a/js/date.js
+++ b/js/date.js
@@ -5,7 +5,7 @@ These are the date related JS scripts for Jappix
 
 -------------------------------------------------
 
-License: AGPL
+License: dual-licensed under AGPL and MPLv2
 Author: Vanaryon
 Last revision: 17/08/11
 

--- a/js/links.js
+++ b/js/links.js
@@ -5,7 +5,7 @@ These are the links JS script for Jappix
 
 -------------------------------------------------
 
-License: AGPL
+License: dual-licensed under AGPL and MPLv2
 Authors: Vanaryon, Maranda
 Last revision: 26/08/11
 


### PR DESCRIPTION
add the MPLv2 license to all Jappix Mini files except mini.js, for which camaran still might need to agree.
