### PR TITLE
Fixes #98 (PHP 5.4 compatibility)

### DIFF
--- a/php/read-hosts.php
+++ b/php/read-hosts.php
@@ -64,7 +64,7 @@ if($hosts_data) {
 		$hosts_value = $hosts_child->getName();
 		
 		// Only push this to the array if it exists
-		if(isset($hosts_conf[$hosts_value]) && $hosts_child)
+		if(isset($hosts_conf[$hosts_value]) && (string)$hosts_child)
 			$hosts_conf[$hosts_value] = str_replace('{PROTOCOL}', $protocol, $hosts_child);
 	}
 }

--- a/php/read-main.php
+++ b/php/read-main.php
@@ -57,7 +57,7 @@ if($main_data) {
 		$main_value = $main_child->getName();
 		
 		// Only push this to the array if it exists
-		if(isset($main_conf[$main_value]) && $main_child)
+		if(isset($main_conf[$main_value]) && (string)$main_child)
 			$main_conf[$main_value] = $main_child;
 	}
 }


### PR DESCRIPTION
Implicit type conversion of SimpleXMLElement in the if clause is no longer working in PHP 5.4.
As a result the code cannot check if the child nodes of the config file have any content.
By typecasting the SimpleXMLElement to a string the behaviour of earlier PHP versions is restored.
