### PR TITLE
Audio notification for users in a MUC

### DIFF
--- a/js/message.js
+++ b/js/message.js
@@ -355,12 +355,11 @@ function handleMessage(message) {
 				}
 				
 				// We notify the user there's a new unread muc message
-				else{
+				else {
 					messageNotify(hash, 'unread');
 
 					//Play sound to all users in the muc, except user who sent the message.
-                    if(myNick != resource)
-                    {
+                    if(myNick != resource) {
                         soundPlay(1);
                     }
 				}


### PR DESCRIPTION
Users in a Multi-User Chat (MUC) who have sound enabled in their
'options' will now receive an audio notification when another user sends
a message in the MUC.  User will not receieve an audio notification from
themselves (when he or she it the person who sends the message).
