### PR TITLE
Fix behaviour when mail is different from PHP_AUTH_USER@host via HTTP auth

### DIFF
--- a/php/functions.php
+++ b/php/functions.php
@@ -754,7 +754,13 @@ function httpAuthEnabled() {
 
 // The function to authenticate with HTTP
 function httpAuthentication() {
-    $host = (isset($_SERVER['HTTP_EMAIL'])) ? substr(strrchr($_SERVER['HTTP_EMAIL'], "@"), 1) : HOST_MAIN;
+    if (isset($_SERVER['HTTP_EMAIL'])) {
+        $user = strstr($_SERVER['HTTP_EMAIL'], "@", true);
+        $host = substr(strrchr($_SERVER['HTTP_EMAIL'], "@"), 1);
+    } else {
+        $user = $_SERVER['PHP_AUTH_USER'];
+        $host = HOST_MAIN;
+    }
     echo '<script type="text/javascript">
             jQuery(document).ready(function() {
                 doHttpLogin("'.$_SERVER['PHP_AUTH_USER'].'", "'.$_SERVER['PHP_AUTH_PW'].'", "'.$host.'", 10);


### PR DESCRIPTION
With HTTP authentication enabled, if the PHP_AUTH_USER `kload` has `hello@kload.fr` as XMPP address (broadcasted as HTTP_EMAIL header), this commit avoids user to be connected as `kload@kload.fr`, and connect with `hello@kload.fr` as it should.
