### PR TITLE
Fix wrong "undefined" comparison

### DIFF
--- a/app/javascripts/autocompletion.js
+++ b/app/javascripts/autocompletion.js
@@ -202,7 +202,7 @@ var Autocompletion = (function () {
             }
             
             // We quote the nick
-            if((nickResult != undefined) && (nick !== undefined)) {
+            if((nickResult !== undefined) && (nick !== undefined)) {
                 // Increment
                 i++;
                 var message = query[1][nickResult[1]];


### PR DESCRIPTION
A little fix of previous commit on autocompletion, where a != was used
instead of a !==
