### PR TITLE
Use the resource when receiving a message from an anonymous account

### DIFF
--- a/app/javascripts/message.js
+++ b/app/javascripts/message.js
@@ -591,7 +591,9 @@ var Message = (function () {
 
             // It does not come from a groupchat user, get the full name
             if(!is_groupchat_user) {
+              if (!Name.buddyIsAnonymous(xid)) {
                 fromName = Name.getBuddy(xid);
+              }
             } else {
                 chatType = 'private';
             }

--- a/app/javascripts/name.js
+++ b/app/javascripts/name.js
@@ -131,26 +131,33 @@ var Name = (function () {
             // Initialize
             var cname, bname;
 
-            // Cut the XID resource
-            xid = Common.bareXID(xid);
+            // If the buddy is an anonymous account we use the resource
+            // if not empty
+            if (self.buddyIsAnonymous(xid) && Common.thisResource(xid)) {
+              bname = Common.thisResource(xid);
+            } else {
 
-            // This is me?
-            if(Utils.isAnonymous() && !xid) {
-                bname = Common._e("You");
-            } else if(xid == Common.getXID()) {
-                bname = self.get();
-            }
+              // Cut the XID resource
+              xid = Common.bareXID(xid);
 
-            // Not me!
-            else {
-                cname = $('#roster .buddy[data-xid="' + escape(xid) + '"]:first .buddy-name').html();
+              // This is me?
+              if(Utils.isAnonymous() && !xid) {
+                  bname = Common._e("You");
+              } else if(xid == Common.getXID()) {
+                  bname = self.get();
+              }
 
-                // Complete name exists?
-                if(cname) {
-                    bname = cname.revertHtmlEnc();
-                } else {
-                    bname = Common.getXIDNick(xid);
-                }
+              // Not me!
+              else {
+                  cname = $('#roster .buddy[data-xid="' + escape(xid) + '"]:first .buddy-name').html();
+
+                  // Complete name exists?
+                  if(cname) {
+                      bname = cname.revertHtmlEnc();
+                  } else {
+                      bname = Common.getXIDNick(xid);
+                  }
+              }
             }
 
             return bname;
@@ -224,6 +231,15 @@ var Name = (function () {
         }
 
     };
+
+    /*
+     * Checks if the XID is from an anonymous account
+     * @public
+     * @param {string} xid
+     */
+    self.buddyIsAnonymous = function(xid) {
+      return /^([a-f\d]{8}(-[a-f\d]{4}){3}-[a-f\d]{12}?)@/ig.test(xid)
+    }
 
 
     /**


### PR DESCRIPTION
I realized that the nickname option for anonymous accounts only applies
to MUCs.  The nickname is sent with every message as per XEP-0172
suggestion but Jappix Desktop nor Pidgin set the nickname using this
method, making the UUID the visible name.

The only part of the full JID that's modifiable for anonymous accounts
is the resource, so this patch checks if the JID is anonymous (the
username is an UUID) and if so, uses the resource.