### PR TITLE
Remove XML namespace filter when getting MAM prefs from server

### DIFF
--- a/app/javascripts/mam.js
+++ b/app/javascripts/mam.js
@@ -75,7 +75,7 @@ var MAM = (function () {
         try {
             if(iq.getType() != 'error') {
                 // Read packet
-                var cur_default = $(iq.getNode()).find('prefs[xmlns="' + NS_URN_MAM + '"]').attr('default') || 'never';
+                var cur_default = $(iq.getNode()).find('prefs').attr('default') || 'never';
 
                 if(!(cur_default in self.PREF_DEFAULTS)) {
                     cur_default = 'never';


### PR DESCRIPTION
Some XMPP servers (e.g. Ejabberd) don't put any XML namespace when sending MAM preferences:

```xml 
<iq xmlns="jabber:client" from="neurolit" to="neurolit/Jappix" id="64" type="result">
   <prefs default="roster">
      <always/>
      <never/>
   </prefs>
</iq>
```
Jappix filters this message out, whereas it should take it into account.

This PR takes care of this.